### PR TITLE
add project name to slack status message

### DIFF
--- a/slack.py
+++ b/slack.py
@@ -89,7 +89,24 @@ class SlackStatusPush(service.BuildbotService):
         if build['complete']:
             build_date = build['complete_at'].strftime('%x %X')
 
-        msg = '{} build for {} on {}.'.format(build['state_string'], build['builder']['name'], build_date)
+        project_name_tuple = build['properties'].get('project_name')
+
+        if project_name_tuple:
+            project_name = project_name_tuple[0]
+
+            msg = '[{}] {} build for {} on {}.'.format(
+                project_name,
+                build['state_string'],
+                build['builder']['name'],
+                build_date
+            )
+        else:
+            msg = '{} build for {} on {}.'.format(
+                build['state_string'],
+                build['builder']['name'],
+                build_date
+            )
+
         if build['complete']:
             msg += ' Build ended in {}'.format(state[0])
         return msg, state[1]


### PR DESCRIPTION
it improves the status message by including a totes proprietary project_name

this should be, like, a hook for configuration or something